### PR TITLE
fix: drift-check workflow の変数・シークレット設定を修正

### DIFF
--- a/.github/workflows/drift-check.yaml
+++ b/.github/workflows/drift-check.yaml
@@ -15,5 +15,13 @@ permissions:
 jobs:
   drift-check:
     uses: gmo-media/tofu-actions/.github/workflows/quickstart-drift-check.yaml@v5
+    # cloneしてきたら各変数とシークレットを設定する（github-tokenはなくても良い）
+    with:
+      workload-identity-provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+      service-account: ${{ vars.SERVICE_ACCOUNT }}
+      anthropic-vertex-project-id: ${{ vars.ANTHROPIC_VERTEX_PROJECT_ID }}
+      cloud-ml-region: ${{ vars.CLOUD_ML_REGION }}
+      anthropic-model: ${{ vars.ANTHROPIC_MODEL }}
     secrets:
-      drift-notify-webhook: "https://hooks.slack.com/services/..."
+      drift-notify-webhook: ${{ secrets.DRIFT_NOTIFY_WEBHOOK }} # infra-team-alert
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `with` ブロックを追加し、`workload-identity-provider` / `service-account` / `anthropic-vertex-project-id` 等を GitHub Variables 経由で設定できるよう修正
- `drift-notify-webhook` をハードコードの Slack URL から `${{ secrets.DRIFT_NOTIFY_WEBHOOK }}` 参照に変更
- `github-token: ${{ secrets.GITHUB_TOKEN }}` を追加

## clone後の対応
各変数を設定することで、drift-fixが利用可能になる。
slackのwebhook以外は、変数を設定しなくても従来のdrift-checkは動きます。